### PR TITLE
[release/1.50.0] Updated module dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_landing_page": "^4.0.0",
-        "dpc-sdp/tide_site": "^4.0.0",
+        "dpc-sdp/tide_core": "^5.0.0",
         "drupal/geofield": "^1.53",
         "drupal/search_api_location": "^1.0@alpha",
         "drupal/migrate_source_csv": "^3.5",

--- a/tide_station_locator.info.yml
+++ b/tide_station_locator.info.yml
@@ -4,6 +4,7 @@ type: module
 package: VicPol
 core_version_requirement: ^9.2 || ^10
 dependencies:
+  - dpc-sdp:tide_core
   - dpc-sdp:tide_landing_page
   - dpc-sdp:tide_site
   - drupal:geofield


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-1585

### Changes
As we moved to mono repo as a part of 1.50.0 change, tide_landing_page and tide_site is a submodule of tide_core now. So removing the old dependencies and adding only tide_core dependency in the composer and updating the info to add dependency to tide_core module.