### PR TITLE
[SCFA-2064] Updated guzzlehttp/psr7 to match with drupal core 10.4.8 requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/migrate_plus": "^6.0",
         "php-http/message": "^1",
         "php-http/message-factory": "^1",
-        "guzzlehttp/psr7": "~2.6.2"
+        "guzzlehttp/psr7": "~2.7.0"
     },
     "extra": {
         "enable-patching": true,


### PR DESCRIPTION
###Jira Ticket
https://digital-vic.atlassian.net/browse/SCFA-2064

###Problem
`Your requirements could not be resolved to an installable set of packages.    Problem 1     - dpc-sdp/tide_station_locator[1.0.3, ..., 1.0.5] require guzzlehttp/psr7 ~2.6.2 -> found guzzlehttp/psr7[2.6.2, 2.6.3, 2.6.x-dev] but it conflicts with your root composer.json require (~2.7.0).     - Root composer.json requires dpc-sdp/tide_station_locator ^1.0.3 -> satisfiable by dpc-sdp/tide_station_locator[1.0.3, 1.0.4, 1.0.5]. `

###Reason
As a part of SDP release 1.54.0, the drupal core is getting updated to 10.4.8 and it requires `guzzlehttp/psr7` to be updated to ~2.7.0

###Fix 
Updated guzzlehttp/psr7 to ~2.7.0