### PR TITLE
Replace fallback expiry date 9999-12-31 with safer 9999-01-01 in `ValidToDt` mapping

### DIFF
--- a/src/StationAPIConnector.php
+++ b/src/StationAPIConnector.php
@@ -245,7 +245,7 @@ class StationAPIConnector {
         }
         // If the date is empty set default value.
         if ($attribute['name'] == 'ValidToDt' && empty($attribute['value'])) {
-          $station['ValidToDt'] = '9999-12-31';
+          $station['ValidToDt'] = '9999-01-01';
         }
 
         // Set the moderationState based on date.

--- a/src/StationAPIConnector.php
+++ b/src/StationAPIConnector.php
@@ -244,7 +244,7 @@ class StationAPIConnector {
           $station['ValidFromDt'] = '1900-01-01';
         }
         // If the date is empty set default value.
-        if ($attribute['name'] == 'ValidToDt' && empty($attribute['value'])) {
+        if ($attribute['name'] == 'ValidToDt' && (empty($attribute['value']) || strtotime($attribute['value']) > strtotime('9999-01-01'))) {
           $station['ValidToDt'] = '9999-01-01';
         }
 


### PR DESCRIPTION
### Issues
adding even one day to `9999-12-31` overflows to `10000-01-01`, and it is sometimes happing, a value unsupported by php, mysql, and Elasticsearch date mapping. This can crash requests or break indexing in production.

our current Drupal migration sometimes fails to normalise 9999-12-31 to 00:00:00, likely a core or Migrate API bug. We don’t have resurces to investigate for now.

9999-01-01 still clearly means "no expiry” but stays comfortably inside every platform’s valid range.

### Communication
advise vicpol to cease supplying 9999-12-31 in any feed or manual entry.